### PR TITLE
Remove client_id

### DIFF
--- a/lib/domainr/operations.rb
+++ b/lib/domainr/operations.rb
@@ -2,7 +2,7 @@ module Domainr
   class Operations
 
     def self.info(domain)
-      response = JSON.parse(Net::HTTP.get(URI("https://api.domainr.com/v1/info?client_id=ruby_pablo_merino&q=#{domain}")))
+      response = JSON.parse(Net::HTTP.get(URI("https://api.domainr.com/v1/info?client_id={your-mashape-key}&q=#{domain}")))
       puts "Domain: #{response['domain']}"
 
       response['registrars'].each do |result|
@@ -17,7 +17,7 @@ module Domainr
 
     def self.search(query)
       @responses_array = Array.new
-      response = JSON.parse(Net::HTTP.get(URI("https://api.domainr.com/v1/search?client_id=ruby_pablo_merino&q=#{query}")))
+      response = JSON.parse(Net::HTTP.get(URI("https://api.domainr.com/v1/search?client_id={your-mashape-key}&q=#{query}")))
       print_domains response
       catch (:done) do
         loop {


### PR DESCRIPTION
Due to API abuse, we're locking these down further. Details in our [API documentation](http://domainr.build/docs/authentication).
